### PR TITLE
Fix for Magento 1.8 layout update name clash/conflict

### DIFF
--- a/app/code/community/Openstream/GeoIP/etc/config.xml
+++ b/app/code/community/Openstream/GeoIP/etc/config.xml
@@ -47,9 +47,9 @@
     <adminhtml>
         <layout>
             <updates>
-                <index>
+                <geoip>
                     <file>openstream/geoip.xml</file>
-                </index>
+                </geoip>
             </updates>
         </layout>
     </adminhtml>


### PR DESCRIPTION
The name of "index" for the layout update file definition, clashes with Mage_Index module. This leads to the Admin > System > Index Management page being blank.

This is due to Magento switching to using xml layout definition, from creating the block on the fly in the controller, within the Mage Index module.
