### PR TITLE
Usage of $_SERVER['REMOTE_ADDR'] will not work on servers behind a reverse proxy

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,7 +1,0 @@
-include.path=${php.global.include.path}
-php.version=PHP_53
-source.encoding=UTF-8
-src.dir=.
-tags.asp=false
-tags.short=false
-web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://www.netbeans.org/ns/project/1">
-    <type>org.netbeans.modules.php.project</type>
-    <configuration>
-        <data xmlns="http://www.netbeans.org/ns/php-project/1">
-            <name>geoip</name>
-        </data>
-    </configuration>
-</project>


### PR DESCRIPTION
$_SERVER['REMOTE_ADDR'] will not contain the actual IP of the client accessing the site, but that of any behind a reverse proxy sitting front-facing

Using a call to Mage::helper('core/http')->getRemoteAddr() instead will produce the correct, expected results, if the required directive were set in the sites config.xml to correctly populate remote_addr

as an example:

```
   <remote_addr_headers><!-- list headers that contain real client IP if webserver is behind a reverse proxy -->
        <header1>HTTP_X_REAL_IP</header1>
        <header2>HTTP_X_FORWARDED_FOR</header2>
    </remote_addr_headers>
```

Additionally, no check is done that REMOTE_ADDR array key was in fact existing.
This would throw an error: Undefined index: REMOTE_ADDR in /app/code/community/Openstream/GeoIP/Model/Country.php on line 12

This can happen when a cron job is causing the GEOIP code to run. - This happens in magento EE send_notifications cron job.
