### PR TITLE
$SERVER['REMOTE_ADDR'] will not contain the actual IP of the client accessing the site, but that of any reverse proxy 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/nbproject/private/


### PR DESCRIPTION
$SERVER['REMOTE_ADDR'] will not contain the actual IP of the client accessing the site, but that of any  reverse proxy 

Using a call to Mage::helper('core/http')->getRemoteAddr() instead will produce the correct, expected results, if the required directive were set in the sites config.xml to correctly populate remote_addr

as an example:

   <remote_addr_headers><!-- list headers that contain real client IP if webserver is behind a reverse proxy -->
        <header1>HTTP_X_REAL_IP</header1>
        <header2>HTTP_X_FORWARDED_FOR</header2>
    </remote_addr_headers>

Additionally, no check is done that REMOTE_ADDR array key was in fact existing.
This would throw an error: Undefined index: REMOTE_ADDR in /app/code/community/Openstream/GeoIP/Model/Country.php on line 12

This can happen when a cron job is causing the GEOIP code to run. - This happens in magento EE send_notifications cron job.
