### PR TITLE
Make database location configurable

### DIFF
--- a/app/code/community/Sandfox/GeoIP/Model/Abstract.php
+++ b/app/code/community/Sandfox/GeoIP/Model/Abstract.php
@@ -19,7 +19,7 @@ class Sandfox_GeoIP_Model_Abstract
     
     public function getRelativeDirectoryPath()
     {
-        return 'var';
+        return Mage::getStoreConfig('general/country/geoip_directory');
     }
 
     public function getAbsoluteDirectoryPath()

--- a/app/code/community/Sandfox/GeoIP/Model/Abstract.php
+++ b/app/code/community/Sandfox/GeoIP/Model/Abstract.php
@@ -7,8 +7,8 @@ class Sandfox_GeoIP_Model_Abstract
     public function __construct()
     {
         $this->local_dir = 'geoip';
-        $this->local_file = Mage::getBaseDir('var') . '/' . $this->local_dir . '/GeoIP.dat';
-        $this->local_archive = Mage::getBaseDir('var') . '/' . $this->local_dir . '/GeoIP.dat.gz';
+        $this->local_file = $this->getAbsoluteDirectoryPath() . '/' . $this->local_dir . '/GeoIP.dat';
+        $this->local_archive = $this->getAbsoluteDirectoryPath() . '/' . $this->local_dir . '/GeoIP.dat.gz';
         $this->remote_archive = 'http://www.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz';
     }
 
@@ -16,25 +16,37 @@ class Sandfox_GeoIP_Model_Abstract
     {
         return $this->local_archive;
     }
+    
+    public function getRelativeDirectoryPath()
+    {
+        return 'var';
+    }
 
+    public function getAbsoluteDirectoryPath()
+    {
+        return Mage::getBaseDir($this->getRelativeDirectoryPath());
+    }
+    
     public function checkFilePermissions()
     {
         /** @var $helper Sandfox_GeoIP_Helper_Data */
         $helper = Mage::helper('geoip');
 
-        $dir = Mage::getBaseDir('var') . '/' . $this->local_dir;
+        $relativeDirPath = $this->getRelativeDirectoryPath();
+
+        $dir = $this->getAbsoluteDirectoryPath() . '/' . $this->local_dir;
         if (file_exists($dir)) {
             if (!is_dir($dir)) {
-                return sprintf($helper->__('%s exists but it is file, not dir.'), 'var/' . $this->local_dir);
+                return sprintf($helper->__('%s exists but it is file, not dir.'), "$relativeDirPath/{$this->local_dir}");
             } elseif ((!file_exists($this->local_file) || !file_exists($this->local_archive)) && !is_writable($dir)) {
-                return sprintf($helper->__('%s exists but files are not and directory is not writable.'), 'var/' . $this->local_dir);
+                return sprintf($helper->__('%s exists but files are not and directory is not writable.'), "$relativeDirPath/{$this->local_dir}");
             } elseif (file_exists($this->local_file) && !is_writable($this->local_file)) {
-                return sprintf($helper->__('%s is not writable.'), 'var/' . $this->local_dir . '/GeoIP.dat');
+                return sprintf($helper->__('%s is not writable.'), "$relativeDirPath/{$this->local_dir}" . '/GeoIP.dat');
             } elseif (file_exists($this->local_archive) && !is_writable($this->local_archive)) {
-                return sprintf($helper->__('%s is not writable.'), 'var/' . $this->local_dir . '/GeoIP.dat.gz');
+                return sprintf($helper->__('%s is not writable.'), "$relativeDirPath/{$this->local_dir}" . '/GeoIP.dat.gz');
             }
         } elseif (!@mkdir($dir)) {
-            return  sprintf($helper->__('Can\'t create %s directory.'), 'var/' . $this->local_dir);
+            return  sprintf($helper->__('Can\'t create %s directory.'), "$relativeDirPath/{$this->local_dir}");
         }
 
         return '';

--- a/app/code/community/Sandfox/GeoIP/etc/config.xml
+++ b/app/code/community/Sandfox/GeoIP/etc/config.xml
@@ -62,4 +62,12 @@
             </geoip_update>
         </jobs>
     </crontab>
+    
+    <default>
+        <general>
+            <country>
+                <geoip_directory>var</geoip_directory>
+            </country>
+        </general>
+    </default>
 </config>

--- a/app/code/community/Sandfox/GeoIP/etc/system.xml
+++ b/app/code/community/Sandfox/GeoIP/etc/system.xml
@@ -22,6 +22,15 @@
                             <show_in_store>0</show_in_store>
                             <comment>If you synchronize GeoIP database too often you may be banned for several hours.</comment>
                         </geoip_synchronize>
+                        <geoip_directory>
+                            <label>GeoIP Database Directory</label>
+                            <comment>The base directory in which the GeoIP database will be stored</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>7020</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </geoip_directory>
                     </fields>
                 </country>
             </groups>


### PR DESCRIPTION
## Problem

Running Magento on multiple servers. We do not share the `var` directory across servers meaning each server needs to get a copy of the database, as well as somehow keep them all in sync.
## Solution

Make the directory location admin panel configurable so that we can define it as `media` which is usually shared across the servers so that images are not duplicated etc.
